### PR TITLE
feat: Implement PDF reader enhancements and rename to Rindle

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
+    <title>Rindle</title>
   </head>
   <body>
     <div id="root"></div>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { Switch, Route } from "wouter";
 import { queryClient } from "./lib/queryClient";
 import { QueryClientProvider } from "@tanstack/react-query";
@@ -19,6 +20,10 @@ function Router() {
 }
 
 function App() {
+  useEffect(() => {
+    document.title = 'Rindle';
+  }, []);
+
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider>

--- a/client/src/components/paper-card.tsx
+++ b/client/src/components/paper-card.tsx
@@ -37,13 +37,13 @@ export function PaperCard({ paper, viewMode }: PaperCardProps) {
         }`}>
           <CardContent className="p-6">
             <div className="flex items-center space-x-6">
-              {/* Thumbnail placeholder */}
-              <div className={`w-16 h-20 rounded flex-shrink-0 flex items-center justify-center ${
-                theme === "light" ? "bg-neutral-100" :
-                theme === "dark" ? "bg-neutral-800" :
-                "bg-[#8B7355]/10"
-              }`}>
-                📄
+              {/* Thumbnail */}
+              <div className={`w-16 h-20 rounded flex-shrink-0 ${theme === "light" ? "bg-neutral-100" : theme === "dark" ? "bg-neutral-800" : "bg-[#8B7355]/10"}`}>
+                {paper.thumbnail ? (
+                  <img src={paper.thumbnail} alt={`${paper.title} thumbnail`} className="w-full h-full object-cover rounded" />
+                ) : (
+                  <div className="w-full h-full flex items-center justify-center text-xl">📄</div>
+                )}
               </div>
               
               <div className="flex-1 min-w-0">
@@ -114,13 +114,13 @@ export function PaperCard({ paper, viewMode }: PaperCardProps) {
       <Card className={`cursor-pointer transition-all duration-300 hover:shadow-xl hover:-translate-y-1 ${
         theme === "sepia" ? "bg-[#F7F3E9] border-[#8B7355]/20" : ""
       }`}>
-        {/* Thumbnail placeholder */}
-        <div className={`w-full h-48 rounded-t-xl flex items-center justify-center text-4xl ${
-          theme === "light" ? "bg-neutral-100" :
-          theme === "dark" ? "bg-neutral-800" :
-          "bg-[#8B7355]/10"
-        }`}>
-          📄
+        {/* Thumbnail */}
+        <div className={`w-full h-48 rounded-t-xl ${theme === "light" ? "bg-neutral-100" : theme === "dark" ? "bg-neutral-800" : "bg-[#8B7355]/10"}`}>
+          {paper.thumbnail ? (
+            <img src={paper.thumbnail} alt={`${paper.title} thumbnail`} className="w-full h-full object-cover rounded-t-xl" />
+          ) : (
+            <div className="w-full h-full flex items-center justify-center text-4xl">📄</div>
+          )}
         </div>
         
         <CardContent className="p-6">

--- a/client/src/pages/library.tsx
+++ b/client/src/pages/library.tsx
@@ -68,7 +68,7 @@ export default function Library() {
           <div className="flex items-center justify-between h-16">
             <div className="flex items-center space-x-4">
               <BookOpen className="h-8 w-8 text-blue-600" />
-              <h1 className="text-xl font-semibold">Rindle Kindle</h1>
+              <h1 className="text-xl font-semibold">Rindle</h1>
             </div>
             
             <div className="flex items-center space-x-4">

--- a/client/src/pages/reader.tsx
+++ b/client/src/pages/reader.tsx
@@ -201,92 +201,49 @@ export default function Reader() {
             </div>
           </div>
 
-          {/* Reading Content with Responsive Columns */}
+          {/* Reading Content - Now renders images */}
           <div 
-            className={`reading-text columns-1 lg:columns-2 gap-8 ${
+            className={`reading-text ${ // Removed column and gap styles
               theme === "light" ? "text-neutral-900" :
               theme === "dark" ? "text-neutral-100" :
               "text-[#5C4B37]"
             }`}
-            style={{ 
-              fontSize: `${fontSize}px`,
-              fontFamily: 'Georgia, serif',
-              lineHeight: 1.7,
-              textAlign: 'justify',
-              columnFill: 'balance'
-            }}
+            // Removed inline styles for fontSize, fontFamily, lineHeight, textAlign, columnFill
           >
-            {/* Sample Academic Content */}
-            <div className="break-inside-avoid mb-6">
-              <h2 className="text-xl font-semibold mb-4 break-after-avoid">Abstract</h2>
-              <p className="mb-4">
-                The dominant sequence transduction models are based on complex recurrent or convolutional neural networks 
-                that include an encoder and a decoder. The best performing models also connect the encoder and decoder 
-                through an attention mechanism. We propose a new simple network architecture, the Transformer, based 
-                solely on attention mechanisms, dispensing with recurrence and convolutions entirely.
-              </p>
-            </div>
+            {(() => {
+              // Ensure paper.content is correctly typed, it should be Array<{type: string, value: string}>
+              // as per shared/schema.ts and server/pdf-processor.ts
+              const contentArray = paper.content as Array<{ type: string; value: string }>;
+              const currentContentPage = contentArray && contentArray[currentPage - 1];
 
-            <div className="break-inside-avoid mb-6">
-              <h2 className="text-xl font-semibold mb-4 break-after-avoid">1. Introduction</h2>
-              <p className="mb-4">
-                Recurrent neural networks, long short-term memory and gated recurrent neural networks in particular, 
-                have been firmly established as state of the art approaches in sequence modeling and transduction 
-                problems such as language modeling and machine translation. Numerous efforts have since continued 
-                to push the boundaries of recurrent language models and encoder-decoder architectures.
-              </p>
-              <p className="mb-4">
-                Recurrent models typically factor computation along the symbol positions of the input and output 
-                sequences. Aligning the positions to steps in computation time, they generate a sequence of hidden 
-                states h_t, as a function of the previous hidden state h_(t-1) and the input for position t.
-              </p>
-            </div>
+              if (isLoading) { // This isLoading is for the paper query, page content itself isn't separately loaded here
+                return <p>Loading paper details...</p>;
+              }
 
-            <div className="break-inside-avoid mb-6">
-              <h2 className="text-xl font-semibold mb-4 break-after-avoid">2. Background</h2>
-              <p className="mb-4">
-                The goal of reducing sequential computation also forms the foundation of the Extended Neural GPU, 
-                ByteNet and ConvS2S, all of which use convolutional neural networks as basic building block, 
-                computing hidden representations in parallel for all input and output positions.
-              </p>
-              <p className="mb-4">
-                In these models, the number of operations required to relate signals from two arbitrary input 
-                or output positions grows in the distance between positions, linearly for ConvS2S and logarithmically 
-                for ByteNet. This makes it more difficult to learn dependencies between distant positions.
-              </p>
-            </div>
+              if (!paper) { // Should be caught by earlier checks, but good for safety
+                return <p>Paper data is not available.</p>;
+              }
 
-            <div className="break-inside-avoid mb-6">
-              <h2 className="text-xl font-semibold mb-4 break-after-avoid">3. Model Architecture</h2>
-              <p className="mb-4">
-                Most competitive neural sequence transduction models have an encoder-decoder structure. Here, 
-                the encoder maps an input sequence of symbol representations (x_1, ..., x_n) to a sequence 
-                of continuous representations z = (z_1, ..., z_n). Given z, the decoder then generates an 
-                output sequence (y_1, ..., y_m) of symbols one element at a time.
-              </p>
-              <p className="mb-4">
-                At each step the model is auto-regressive, consuming the previously generated symbols as 
-                additional input when generating the next. The Transformer follows this overall architecture 
-                using stacked self-attention and point-wise, fully connected layers for both the encoder 
-                and decoder, shown in the left and right halves of Figure 1, respectively.
-              </p>
-            </div>
-
-            <div className={`${
-              theme === "light" ? "bg-neutral-50" :
-              theme === "dark" ? "bg-neutral-800" :
-              "bg-[#8B7355]/5"
-            } p-4 sm:p-6 rounded-lg break-inside-avoid mb-6`}>
-              <p className={`italic text-sm ${
-                theme === "light" ? "text-neutral-600" :
-                theme === "dark" ? "text-neutral-400" :
-                "text-[#8B7355]"
-              }`}>
-                This is sample content to demonstrate the responsive layout. In a production environment, 
-                the actual paper content would be extracted from the uploaded {paper.filename?.endsWith('.pdf') ? 'PDF' : 'DOCX'} file 
-                using PDF.js for PDF files or Mammoth.js for DOCX files, maintaining proper formatting and structure.
-              </p>
-            </div>
+              if (currentContentPage && currentContentPage.type === 'image') {
+                return (
+                  <img
+                    src={currentContentPage.value}
+                    alt={`Page ${currentPage} of ${paper.totalPages}`}
+                    style={{
+                      width: '100%',
+                      height: 'auto',
+                      objectFit: 'contain',
+                      margin: '0 auto', // Center the image if it's narrower than the container
+                      maxWidth: '800px' // Optional: constrain max width for very large screens
+                    }}
+                  />
+                );
+              } else if (currentContentPage) {
+                return <p>Unsupported content type for this page: {currentContentPage.type}.</p>;
+              } else {
+                return <p>No content available for this page ({currentPage} of {paper.totalPages}).</p>;
+              }
+            })()}
           </div>
         </div>
       </main>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4189,7 +4189,6 @@
       "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.1.0.tgz",
       "integrity": "sha512-tTj3CqqukVJ9NgSahykNwtGda7V33VLObwrHfzT0vqJXu7J4d4C/7kQQW3fOEGDfZZoILPut5H00gOjyttPGyg==",
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "node-addon-api": "^7.0.0",
         "prebuild-install": "^7.1.1"
@@ -6949,7 +6948,6 @@
       "version": "5.3.31",
       "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.3.31.tgz",
       "integrity": "sha512-EhPdIjNX0fcdwYQO+e3BAAJPXt+XI29TZWC7COhIXs/K0JHcUt1Gdz1ITpebTwVMFiLsukdUZ3u0oTO7jij+VA==",
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=20.16.0 || >=22.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rest-express",
+  "name": "rindle",
   "version": "1.0.0",
   "type": "module",
   "license": "MIT",

--- a/server/pdf-processor.ts
+++ b/server/pdf-processor.ts
@@ -1,157 +1,110 @@
+import * as pdfjsLib from 'pdfjs-dist/legacy/build/pdf.js';
+import { createCanvas } from 'canvas';
+
 interface ProcessedPDFData {
   title: string;
   authors: string;
-  content: string;
+  // content field is now a JSONB array of objects, e.g. [{type: 'image', value: 'base64_string'}]
+  content: Array<{ type: string; value: string }>;
   totalPages: number;
   thumbnail: string;
   metadata: {
     journal?: string;
     year?: number;
     doi?: string;
+    // Add other relevant metadata fields if needed
+    rawInfo?: any; // To store the raw PDF metadata info
   };
 }
 
-export async function processPDF(buffer: Buffer): Promise<ProcessedPDFData> {
+// Helper function to convert stream to buffer (if needed, pdfjsLib.getDocument also accepts Uint8Array)
+// For this implementation, we assume `buffer` is already a Buffer or Uint8Array
+
+export async function processPDF(buffer: Buffer, originalFilename?: string): Promise<ProcessedPDFData> {
   try {
-    // For now, we'll implement a basic PDF processor that extracts metadata from filename
-    // and provides sample academic content. In production, you would use PDF.js or similar
-    
-    // Generate a placeholder thumbnail (simple academic paper icon)
-    const thumbnail = generatePaperThumbnail();
-    
-    // Sample academic content that demonstrates the layout
-    const sampleContent = generateSampleAcademicContent();
-    
+    const loadingTask = pdfjsLib.getDocument({ data: buffer });
+    const pdf = await loadingTask.promise;
+
+    let title = originalFilename?.replace(/\.pdf$/i, '') || 'Untitled';
+    let authors = 'Unknown';
+    let rawInfo: any = null;
+    let journal: string | undefined;
+    let year: number | undefined;
+    let doi: string | undefined;
+
+    try {
+      const metadata = await pdf.getMetadata();
+      rawInfo = metadata.info;
+      if (rawInfo?.Title) {
+        title = rawInfo.Title;
+      }
+      if (rawInfo?.Author) {
+        authors = rawInfo.Author;
+      }
+      // You can extract more metadata if available, e.g. Subject for journal, Keywords for tags
+      // For year, it might be in CreationDate or ModDate, need parsing:
+      // e.g. rawInfo.CreationDate (D:20230315...) -> 2023
+      if (rawInfo?.CreationDate && typeof rawInfo.CreationDate === 'string' && rawInfo.CreationDate.startsWith('D:')) {
+        const yearStr = rawInfo.CreationDate.substring(2, 6);
+        const parsedYear = parseInt(yearStr, 10);
+        if (!isNaN(parsedYear)) {
+          year = parsedYear;
+        }
+      }
+      // DOI is not a standard PDF metadata field, might need to search in text or leave for manual input
+
+    } catch (metaError) {
+      console.warn('Could not parse PDF metadata:', metaError);
+    }
+
+    // 1. Thumbnail Generation (first page, small scale)
+    const firstPage = await pdf.getPage(1);
+    const thumbViewport = firstPage.getViewport({ scale: 0.2 }); // Scale down for thumbnail
+    const thumbCanvas = createCanvas(thumbViewport.width, thumbViewport.height);
+    const thumbContext = thumbCanvas.getContext('2d');
+    await firstPage.render({ canvasContext: thumbContext, viewport: thumbViewport }).promise;
+    const thumbnail = thumbCanvas.toDataURL('image/png');
+
+    // 2. Content Extraction (render each page as an image)
+    const structuredContent: Array<{ type: string; value: string }> = [];
+    const totalPages = pdf.numPages;
+
+    for (let i = 1; i <= totalPages; i++) {
+      const page = await pdf.getPage(i);
+      // Render page at a reasonable scale for viewing, e.g., width 800px
+      // Adjust scale to fit a target width, e.g., 800px
+      const desiredWidth = 800;
+      const viewport = page.getViewport({ scale: 1 });
+      const scale = desiredWidth / viewport.width;
+      const scaledViewport = page.getViewport({ scale });
+
+      const pageCanvas = createCanvas(scaledViewport.width, scaledViewport.height);
+      const pageContext = pageCanvas.getContext('2d');
+
+      await page.render({ canvasContext: pageContext, viewport: scaledViewport }).promise;
+      const pageImageBase64 = pageCanvas.toDataURL('image/png');
+      structuredContent.push({ type: 'image', value: pageImageBase64 });
+    }
+
     return {
-      title: "Attention Is All You Need",
-      authors: "Ashish Vaswani, Noam Shazeer, Niki Parmar, Jakob Uszkoreit, Llion Jones, Aidan N. Gomez, Lukasz Kaiser, Illia Polosukhin",
-      content: sampleContent,
-      totalPages: 15,
+      title,
+      authors,
+      content: structuredContent,
+      totalPages,
       thumbnail,
       metadata: {
-        journal: "Advances in Neural Information Processing Systems",
-        year: 2017,
-        doi: "10.48550/arXiv.1706.03762",
-      }
+        journal,
+        year,
+        doi,
+        rawInfo, // Store raw metadata for potential future use or display
+      },
     };
   } catch (error) {
     console.error('PDF processing error:', error);
-    throw new Error('Failed to process PDF file');
-  }
-}
-
-function generatePaperThumbnail(): string {
-  // Generate a simple SVG thumbnail for academic papers
-  const svg = `
-    <svg width="200" height="260" xmlns="http://www.w3.org/2000/svg">
-      <rect width="200" height="260" fill="#ffffff" stroke="#e5e7eb" stroke-width="2"/>
-      <rect x="20" y="20" width="160" height="8" fill="#374151"/>
-      <rect x="20" y="40" width="120" height="6" fill="#6b7280"/>
-      <rect x="20" y="55" width="140" height="6" fill="#6b7280"/>
-      <rect x="20" y="80" width="160" height="4" fill="#9ca3af"/>
-      <rect x="20" y="90" width="150" height="4" fill="#9ca3af"/>
-      <rect x="20" y="100" width="130" height="4" fill="#9ca3af"/>
-      <rect x="20" y="120" width="160" height="4" fill="#9ca3af"/>
-      <rect x="20" y="130" width="140" height="4" fill="#9ca3af"/>
-      <rect x="20" y="140" width="160" height="4" fill="#9ca3af"/>
-      <rect x="20" y="160" width="160" height="4" fill="#9ca3af"/>
-      <rect x="20" y="170" width="120" height="4" fill="#9ca3af"/>
-      <rect x="20" y="180" width="150" height="4" fill="#9ca3af"/>
-    </svg>
-  `;
-  
-  return `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`;
-}
-
-function generateSampleAcademicContent(): string {
-  return `Abstract
-
-The dominant sequence transduction models are based on complex recurrent or convolutional neural networks that include an encoder and a decoder. The best performing models also connect the encoder and decoder through an attention mechanism. We propose a new simple network architecture, the Transformer, based solely on attention mechanisms, dispensing with recurrence and convolutions entirely. Experiments on two machine translation tasks show these models to be superior in quality while being more parallelizable and requiring significantly less time to train. Our model achieves 28.4 BLEU on the WMT 2014 English-to-German translation task, improving over the existing best results, including ensembles, by over 2 BLEU. On the WMT 2014 English-to-French translation task, our model establishes a new single-model state-of-the-art BLEU score of 41.8 after training for 3.5 days on eight GPUs, a small fraction of the training costs of the best models from the literature.
-
-1 Introduction
-
-Recurrent neural networks, long short-term memory [13] and gated recurrent [7] neural networks in particular, have been firmly established as state of the art approaches in sequence modeling and transduction problems such as language modeling and machine translation [35, 2, 5]. Numerous efforts have since continued to push the boundaries of recurrent language models and encoder-decoder architectures [38, 24, 15].
-
-Recurrent models typically factor computation along the symbol positions of the input and output sequences. Aligning the positions to steps in computation time, they generate a sequence of hidden states ht, as a function of the previous hidden state ht−1 and the input for position t. This inherently sequential nature precludes parallelization within training examples, which becomes critical at longer sequence lengths, as memory constraints limit batching across examples. Recent work has achieved significant improvements in computational efficiency through factorization tricks [21] and conditional computation [32], while also improving model performance in the latter case. The fundamental computational constraints, however, remain.
-
-2 Background
-
-The goal of reducing sequential computation also forms the foundation of the Extended Neural GPU [16], ByteNet [18] and ConvS2S [9], all of which use convolutional neural networks as basic building block, computing hidden representations in parallel for all input and output positions. In these models, the number of operations required to relate signals from two arbitrary input or output positions grows in the distance between positions, linearly for ConvS2S and logarithmically for ByteNet. This makes it more difficult to learn dependencies between distant positions [12]. In the Transformer this is reduced to a constant number of operations, albeit at the cost of reduced effective resolution due to averaging attention-weighted positions, an effect we counteract with Multi-Head Attention as described in section 3.2.
-
-Self-attention, sometimes called intra-attention is an attention mechanism relating different positions of a single sequence in order to compute a representation of the sequence. Self-attention has been used successfully in a variety of tasks including reading comprehension, abstractive summarization and textual entailment [4, 27, 28].
-
-End-to-end memory networks are based on a recurrent attention mechanism instead of sequence-aligned recurrence and have been shown to perform well on simple-language question answering and language modeling tasks [34].
-
-3 Model Architecture
-
-Most competitive neural sequence transduction models have an encoder-decoder structure [5, 2, 35]. Here, the encoder maps an input sequence of symbol representations (x1, ..., xn) to a sequence of continuous representations z = (z1, ..., zn). Given z, the decoder then generates an output sequence (y1, ..., ym) of symbols one element at a time. At each step the model is auto-regressive [10], consuming the previously generated symbols as additional input when generating the next.
-
-The Transformer follows this overall architecture using stacked self-attention and point-wise, fully connected layers for both the encoder and decoder, shown in the left and right halves of Figure 1, respectively.
-
-3.1 Encoder and Decoder Stacks
-
-Encoder: The encoder is composed of a stack of N = 6 identical layers. Each layer has two sub-layers. The first is a multi-head self-attention mechanism, and the second is a simple, position-wise fully connected feed-forward network. We employ a residual connection [11] around each of the two sub-layers, followed by layer normalization [1]. That is, the output of each sub-layer is LayerNorm(x + Sublayer(x)), where Sublayer(x) is the function implemented by the sub-layer itself. To facilitate these residual connections, all sub-layers in the model, as well as the embedding layers, produce outputs of dimension dmodel = 512.
-
-Decoder: The decoder is also composed of a stack of N = 6 identical layers. In addition to the two sub-layers in each encoder layer, the decoder inserts a third sub-layer, which performs multi-head attention over the output of the encoder stack. Similar to the encoder, we employ residual connections around each of the sub-layers, followed by layer normalization. We also modify the self-attention sub-layer in the decoder stack to prevent positions from attending to subsequent positions. This masking, combined with fact that the output embeddings are offset by one position, ensures that the predictions for position i can depend only on the known outputs at positions less than i.`;
-}
-
-async function extractMetadata(firstPageText: string, fullContent: string) {
-  const metadata: any = {};
-  
-  // Extract title (usually the first large text block)
-  const titleMatch = firstPageText.match(/^(.{10,200}?)(?:\n|$)/);
-  if (titleMatch) {
-    metadata.title = titleMatch[1].trim();
-  }
-  
-  // Extract authors (look for common patterns)
-  const authorPatterns = [
-    /Authors?:\s*([^\n]+)/i,
-    /By\s+([^\n]+)/i,
-    /^([A-Z][a-z]+\s+[A-Z][a-z]+(?:\s*,\s*[A-Z][a-z]+\s+[A-Z][a-z]+)*)/m,
-  ];
-  
-  for (const pattern of authorPatterns) {
-    const match = firstPageText.match(pattern);
-    if (match) {
-      metadata.authors = match[1].trim();
-      break;
+    // Check if the error is from pdfjs-dist and provide more specific feedback
+    if (error.name === 'InvalidPDFException' || error.name === 'MissingPDFException' || error.name === 'UnexpectedResponseException') {
+        throw new Error(`Failed to process PDF: ${error.message}`);
     }
+    throw new Error('Failed to process PDF file due to an unexpected error.');
   }
-  
-  // Extract DOI
-  const doiMatch = fullContent.match(/DOI:\s*([^\s\n]+)/i);
-  if (doiMatch) {
-    metadata.doi = doiMatch[1];
-  }
-  
-  // Extract year
-  const yearMatch = fullContent.match(/\b(19|20)\d{2}\b/g);
-  if (yearMatch) {
-    const currentYear = new Date().getFullYear();
-    const validYears = yearMatch
-      .map(y => parseInt(y))
-      .filter(y => y <= currentYear && y >= 1900)
-      .sort((a, b) => b - a);
-    
-    if (validYears.length > 0) {
-      metadata.year = validYears[0];
-    }
-  }
-  
-  // Extract journal name (look for common patterns)
-  const journalPatterns = [
-    /(?:Published in|Journal of|Proceedings of|Conference on)\s+([^\n]+)/i,
-    /^([A-Z][^.\n]*(?:Journal|Conference|Proceedings|Review|Letters)[^.\n]*)/m,
-  ];
-  
-  for (const pattern of journalPatterns) {
-    const match = fullContent.match(pattern);
-    if (match) {
-      metadata.journal = match[1].trim();
-      break;
-    }
-  }
-  
-  return metadata;
 }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, serial, integer, jsonb, timestamp } from "drizzle-orm/pg-core";
+import { pgTable, text, serial, integer, jsonb, timestamp, sql } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
@@ -10,7 +10,7 @@ export const papers = pgTable("papers", {
   year: integer("year"),
   doi: text("doi"),
   filename: text("filename").notNull(),
-  content: text("content").notNull(),
+  content: jsonb("content").notNull().default(sql`'[]'::jsonb`),
   thumbnail: text("thumbnail"), // Base64 encoded first page image
   progress: integer("progress").default(0),
   totalPages: integer("total_pages").default(1),


### PR DESCRIPTION
This commit introduces several significant updates to the PDF handling and branding of the application.

Key changes include:

- Server-Side PDF Processing:
  - Integrated `pdfjs-dist` and `canvas` libraries.
  - The `processPDF` function now generates a thumbnail (PNG image of the first page) for each uploaded PDF.
  - It also processes the PDF into a series of full-page images (PNGs), which are stored in the `content` field of the `Paper` record. This allows for paginated viewing with all diagrams and formatting preserved.
  - PDF metadata (title, authors) is extracted.

- Client-Side Reader Updates:
  - The reader page (`/reader/:id`) now displays PDF content as a sequence of images, one per page, using the data from `paper.content`.
  - Pagination controls allow navigation through these page images.
  - The paper card component in the library now displays the generated thumbnail instead of a placeholder icon.

- Schema Changes:
  - The `content` field in the `papers` table (shared/schema.ts) has been changed from `text` to `jsonb` to store the array of page image data. It defaults to an empty array.

- Branding and Naming:
  - The application's title is now "Rindle" (updated in index.html, package.json, and App.tsx).
  - The specific mention of "Kindle" in the library page's header has been removed.

- Dependencies:
  - Added `pdfjs-dist` for PDF manipulation.
  - Added `canvas` for server-side image rendering.